### PR TITLE
ステップ26: エラーページを適切に設定しよう

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,14 @@ class ApplicationController < ActionController::Base
   class Forbidden < ActionController::ActionControllerError; end
   rescue_from Forbidden, with: :rescue403
 
+  rescue_from Exception, with: :rescue500
+  rescue_from ActiveRecord::RecordNotFound, with: :rescue404
+  rescue_from ActionController::RoutingError, with: :rescue404
+
+  def routing_error
+    raise ActionController::RoutingError, params[:path]
+  end
+
   private
 
   # ユーザーの情報を取得するメソッド
@@ -21,5 +29,13 @@ class ApplicationController < ActionController::Base
   # 403エラー時に表示する画面
   def rescue403
     render file: 'public/403.html', status: 403, layout: false
+  end
+
+  def rescue404
+    render 'errors/404', status: :not_found
+  end
+ 
+  def rescue500
+    render 'errors/500', status: :internal_server_error
   end
 end

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,0 +1,4 @@
+<div class="text-center">
+  <h1>403 Not Found</h1>
+  <p>お探しのページは見つかりませんでした</p>
+</div>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,4 +1,4 @@
 <div class="text-center">
-  <h1>403 Not Found</h1>
+  <h1>404 Not Found</h1>
   <p>お探しのページは見つかりませんでした</p>
 </div>

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -1,0 +1,7 @@
+<div class="text-center">
+  <h1>500 Internal Server Error</h1>
+  <p>このページを表示できません</p>
+  <div class="font-weight-bold">
+    <p>CGIやRubyなど内部参照におけるエラーの為、<br>目的のページが表示できなかったことを意味します。</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,8 @@ Rails.application.routes.draw do
     resources :users
   end
   resources :tasks
+
+  get '*not_found', to: 'application#routing_error'
+  post '*not_found', to: 'application#routing_error'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 処理概要
- [ ] 404エラー画面を新規作成
- [ ] 500エラー画面を新規作成
- [ ] application_controller.rbに404と500のエラーが発生した際の処理を設定
- [ ] routes.rbにnot_found時のルーティングを追記

## 要件・仕様
* Railsが用意しているデフォルトのエラーページを自分が作った画面にしてみましょう
* 状況に応じて、適切にエラーページを設定しましょう
    * ステータスコードの404ページと500ページの2種類の設定は少なくとも必須とします

## 特記
複雑な処理が含まれる場合は、設計・実装方針を記載してください
※ コードにコメントと言う形での記載も可

## 動作確認観点
### 500エラー画面（tasks_controller.rbのindexアクションにraiseを記載し意図的にエラーを発生させました）
<img width="839" alt="500エラー画面" src="https://user-images.githubusercontent.com/52454270/91922989-3e5d9e00-ed0a-11ea-9cd4-d1b14fb12c25.png">

### 404エラー画面
<img width="838" alt="スクリーンショット 2020-09-02 10 54 01" src="https://user-images.githubusercontent.com/52454270/91923167-a318f880-ed0a-11ea-8c24-938fd9b942d3.png">

## 参考
https://stress-hack.fun/%E5%8B%95%E7%9A%84%E3%81%AA404%E3%83%9A%E3%83%BC%E3%82%B8%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B/
https://morizyun.github.io/blog/custom-error-404-500-page/index.html